### PR TITLE
FIX dead loops check

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function buildDependentsTree (node, paths = [], leafs = []) {
   }
 
   // prevent dead loops
-  if (paths.includes(name)) {
+  if (paths.map(p => p.name).includes(name)) {
     return { name, version, leafs }
   }
 


### PR DESCRIPTION
Fixes #269

Paths contains structs, not just names, and so this check would previously fail with the error "Cannot read properties of undefined (reading 'length')".

See [this comment](https://github.com/amio/npm-why/issues/269#issuecomment-963020865).