### PR TITLE
Fix recursive dependencies. Fixes #269.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function buildDependentsTree (node, paths = [], leafs = []) {
   }
 
   // prevent dead loops
-  if (paths.includes(name)) {
+  if (paths.map(p => p.name).includes(name)) {
     return { name, version, leafs }
   }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ async function main (dir, packageName) {
   const reasons = await collectReasons(dir, packageName).catch(e => {
     if (e.code === 'ENOLOCK') {
       throw new Error('package.json or lockfile not found.')
+    } else {
+      throw e;
     }
   })
 

--- a/test/bin.spec.js
+++ b/test/bin.spec.js
@@ -56,3 +56,22 @@ tap.test('Exit 1 if no lockfile presented', async t => {
   t.equal(exitCode, 1, 'exit code 1')
   t.equal(stderr.trim(), 'ERROR package.json or lockfile not found.')
 })
+
+// Issue #269
+tap.test('Support recursive dependencies', async t => {
+  const cwd = path.join(__dirname, 'fixtures/recursive-dependency')
+
+  {
+    const { stdout } = await cli(['a', '--noir'], { cwd })
+    t.equal(stdout.trim(), `Who required a:
+
+  recursive-dependency > a@1.0.0`, 'output correct result.')
+  }
+
+  {
+    const { stdout } = await cli(['b', '--noir'], { cwd })
+    t.equal(stdout.trim(), `Who required b:
+
+  recursive-dependency > a > b@1.0.0`, 'output correct result.')
+  }
+})

--- a/test/fixtures/recursive-dependency/package-lock.json
+++ b/test/fixtures/recursive-dependency/package-lock.json
@@ -21,7 +21,7 @@
       "resolved": "https://not-a-registry.npmjs.org/b/-/b-1.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "peerDependencies": {
-        "a": ">=5"
+        "a": ">=1"
       }
     }
   },

--- a/test/fixtures/recursive-dependency/package-lock.json
+++ b/test/fixtures/recursive-dependency/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "recursive-dependency",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "a": "^1.0.0"
+      }
+    },
+    "node_modules/a": {
+      "version": "1.0.0",
+      "resolved": "https://not-a-registry.npmjs.org/a/-/a-1.0.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
+      "dependencies": {
+        "b": "^1.0.0"
+      }
+    },
+    "node_modules/b": {
+      "version": "1.0.0",
+      "resolved": "https://not-a-registry.npmjs.org/b/-/b-1.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "peerDependencies": {
+        "a": ">=5"
+      }
+    }
+  },
+  "dependencies": {
+    "a": {
+      "version": "1.0.0",
+      "resolved": "https://not-a-registry.npmjs.org/a/-/a-1.0.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
+      "requires": {
+        "b": "^1.0.0"
+      }
+    },
+    "b": {
+      "version": "1.0.0",
+      "resolved": "https://not-a-registry.npmjs.org/b/-/b-1.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA=="
+    }
+  }
+}

--- a/test/fixtures/recursive-dependency/package.json
+++ b/test/fixtures/recursive-dependency/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "a": "^1.0.0"
+  }
+}


### PR DESCRIPTION
- Add a test. Without the fix, it will currently fail.
- Prevent dead loops. Fixes failing test.
- Don't hide thrown exceptions.
